### PR TITLE
Initial starter java project based on GCP.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,4 @@
+build --javabase=@bazel_tools//tools/jdk:remote_jdk11
+build --java_toolchain=@bazel_tools//tools/jdk:remote_toolchain
+build --javacopt="-source 11"
+build --javacopt="-target 11"

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,8 @@
+test_suite(
+    name = "test_example",
+    tests = [
+        "//src:cloud_function_integration_test",
+        "//src:cloud_function_system_test",
+        "//src:cloud_function_test",
+    ],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,27 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+RULES_JVM_EXTERNAL_TAG = "4.0"
+
+RULES_JVM_EXTERNAL_SHA = "31701ad93dbfe544d597dbe62c9a1fdd76d81d8a9150c2bf1ecf928ecdf97169"
+
+http_archive(
+    name = "rules_jvm_external",
+    sha256 = RULES_JVM_EXTERNAL_SHA,
+    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
+    url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
+)
+
+load("@rules_jvm_external//:defs.bzl", "maven_install")
+
+maven_install(
+    artifacts = [
+        "com.google.cloud.functions:functions-framework-api:1.0.1",
+        "com.google.cloud.functions:function-maven-plugin:0.9.7",
+        "org.junit.jupiter:junit-jupiter-engine:5.7.1",
+        "org.mockito:mockito-core:2.21.0",
+    ],
+    repositories = [
+        "https://maven.google.com",
+        "https://repo1.maven.org/maven2",
+    ],
+)

--- a/src/BUILD
+++ b/src/BUILD
@@ -1,0 +1,50 @@
+common_deps = [
+    "@maven//:com_google_cloud_functions_function_maven_plugin",
+    "@maven//:com_google_cloud_functions_functions_framework_api",
+]
+
+java_library(
+    name = "cloud_function",
+    srcs = [
+        "main/java/com/example/Example.java",
+    ],
+    deps = common_deps,
+)
+
+common_test_deps = [
+    "@maven//:org_junit_jupiter_junit_jupiter_engine",
+    "@maven//:org_mockito_mockito_core",
+]
+
+java_test(
+    name = "cloud_function_test",
+    srcs = [
+        "test/java/com/example/ExampleTest.java",
+    ],
+    test_class = "com.example.ExampleTest",
+    deps = [
+        ":cloud_function",
+    ] + common_deps + common_test_deps,
+)
+
+java_test(
+    name = "cloud_function_integration_test",
+    srcs = [
+        "test/java/com/example/ExampleIntegrationTest.java",
+    ],
+    test_class = "com.example.ExampleIntegrationTest",
+    deps = [
+        ":cloud_function",
+    ] + common_deps + common_test_deps,
+)
+
+java_test(
+    name = "cloud_function_system_test",
+    srcs = [
+        "test/java/com/example/ExampleSystemTest.java",
+    ],
+    test_class = "com.example.ExampleSystemTest",
+    deps = [
+        ":cloud_function",
+    ] + common_test_deps + common_deps,
+)

--- a/src/main/java/com/example/Example.java
+++ b/src/main/java/com/example/Example.java
@@ -1,0 +1,14 @@
+package com.example;
+
+import com.google.cloud.functions.HttpFunction;
+import com.google.cloud.functions.HttpRequest;
+import com.google.cloud.functions.HttpResponse;
+import java.io.BufferedWriter;
+
+public class Example implements HttpFunction {
+  @Override
+  public void service(HttpRequest request, HttpResponse response) throws Exception {
+    BufferedWriter writer = response.getWriter();
+    writer.write("Hello world!");
+  }
+}

--- a/src/test/java/com/example/ExampleIntegrationTest.java
+++ b/src/test/java/com/example/ExampleIntegrationTest.java
@@ -1,0 +1,106 @@
+package com.example;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.BufferedWriter;
+import java.io.BufferedReader;
+import java.io.StringReader;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.Executors;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+import com.google.cloud.functions.HttpResponse;
+import com.google.cloud.functions.HttpRequest;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+public class ExampleIntegrationTest {
+    //Root URL pointing to the locally hosted function
+    private static final String BASE_URL = "http://localhost:8080";
+
+    private static HttpClient client = HttpClient.newHttpClient();
+    private static ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor)Executors.newFixedThreadPool(10);
+
+    private static HttpServer server;
+
+    @BeforeClass
+    public static void setUp() throws IOException {
+
+        server = HttpServer.create(new InetSocketAddress("localhost", 8080), 0);
+        server.createContext("/", new HttpHandler() {
+            private Example example = new Example();
+            private StringWriter responseOut;
+            private BufferedWriter writerOut;
+
+            @Mock private HttpRequest request;
+            @Mock private HttpResponse response;
+            {
+                MockitoAnnotations.initMocks(this);
+
+                //use an empty string as the default request content
+                var reader  = new BufferedReader(new StringReader(""));
+                when(request.getReader()).thenReturn(reader);
+
+                responseOut = new StringWriter();
+                writerOut = new BufferedWriter(responseOut);
+                when(response.getWriter()).thenReturn(writerOut);
+            }
+
+            @Override
+            public void handle(HttpExchange httpExchange) {
+                try {
+                    example.service(request, response);
+                    writerOut.flush();
+                    String response = responseOut.toString();
+                    httpExchange.sendResponseHeaders(200, response.length());
+                    var outStream = httpExchange.getResponseBody();
+                    outStream.write(response.getBytes());
+                    outStream.close();
+                } catch (Exception e) {
+                    throw new RuntimeException(e.getCause());
+                }
+            }
+        });
+
+        server.setExecutor(threadPoolExecutor);
+        server.start();
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        server.stop(0);
+        threadPoolExecutor.shutdown();
+    }
+
+    @Test
+    public void integrationTest() throws Throwable {
+        var functionUrl = BASE_URL;
+
+        var getRequest = java.net.http.HttpRequest.newBuilder()
+                .version(HttpClient.Version.HTTP_2)
+                .uri(URI.create(functionUrl))
+                .headers("Content-Type", "application/json;charset=UTF-8")
+                .build();
+
+        String body = client.send(
+                getRequest,
+                java.net.http.HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8)).body();
+
+        assertEquals("Hello world!", body);
+    }
+}

--- a/src/test/java/com/example/ExampleSystemTest.java
+++ b/src/test/java/com/example/ExampleSystemTest.java
@@ -1,0 +1,23 @@
+package com.example;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class ExampleSystemTest {
+    @Test
+    public void shouldRunWithDeployedFunction() throws IOException, InterruptedException {
+        //Root URL pointing to the Cloud Functions deployment
+        String functionUrl = System.getenv("FUNCTIONS_BASE_URL");
+
+        var getRequest = HttpRequest.newBuilder().uri(URI.create(functionUrl)).build();
+        var response = HttpClient.newHttpClient().send(getRequest, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals("Hello world!", response.body());
+    }
+}

--- a/src/test/java/com/example/ExampleTest.java
+++ b/src/test/java/com/example/ExampleTest.java
@@ -1,0 +1,49 @@
+package com.example;
+
+import com.google.cloud.functions.HttpRequest;
+import com.google.cloud.functions.HttpResponse;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.Mockito.when;
+
+public class ExampleTest {
+    @Mock private HttpRequest request;
+    @Mock private HttpResponse response;
+
+    private BufferedWriter writerOut;
+    private StringWriter responseOut;
+
+    @Before
+    public void beforeTest() throws IOException {
+        MockitoAnnotations.initMocks(this);
+
+        //use an empty string as the default request content
+        var reader  = new BufferedReader(new StringReader(""));
+        when(request.getReader()).thenReturn(reader);
+
+        responseOut = new StringWriter();
+        writerOut = new BufferedWriter(responseOut);
+        when(response.getWriter()).thenReturn(writerOut);
+    }
+
+    @Test
+    public void simpleExampleTest() throws Exception {
+        new Example().service(request, response);
+
+        writerOut.flush();
+
+        assertEquals(responseOut.toString(), "Hello world!");
+    }
+}


### PR DESCRIPTION
This PR adds the java starter project based on GCP by following the tutorials as mentioned below.

Tutorial links:
1. https://cloud.google.com/functions/docs/quickstart-java
2. https://cloud.google.com/functions/docs/first-java#maven_3
3. https://cloud.google.com/functions/docs/testing/test-http#functions-testing-http-integration-cmd-java

Additional sites that are referenced:
1. https://dzone.com/articles/simple-http-server-in-java
2. https://stackoverflow.com/questions/3732109/simple-http-server-in-java-using-only-java-se-api
3. https://github.com/bazelbuild/rules_jvm_external